### PR TITLE
fix: LRU cache, resource leak and buffered writer optimization

### DIFF
--- a/data_dir.go
+++ b/data_dir.go
@@ -36,10 +36,10 @@ func (d *dataDir) getVdbFileNames() vdbFileNames {
 
 func (d *dataDir) readFile(fileName string, f func(*entry)) error {
 	fd, err := os.Open(filepath.Join(d.path, fileName))
-	defer fd.Close()
 	if err != nil {
 		return err
 	}
+	defer fd.Close()
 	readEntryFormFile(fd, f)
 	return nil
 }

--- a/file.go
+++ b/file.go
@@ -23,6 +23,7 @@ type vdbFile struct {
 	fileFullName string
 	fileIndex    int
 	file         *os.File
+	writer       *bufio.Writer
 	offset       int64
 	maxSize      int64
 }
@@ -34,7 +35,14 @@ func newVdbFile(fileName string, maxSize int64) (*vdbFile, error) {
 	}
 	offset, _ := file.Seek(0, io.SeekEnd)
 	fid, _ := getFileId(file.Name())
-	return &vdbFile{file: file, maxSize: maxSize, offset: offset, fileFullName: fileName, fileIndex: fid}, nil
+	return &vdbFile{
+		file:         file,
+		writer:       bufio.NewWriterSize(file, 64*1024),
+		maxSize:      maxSize,
+		offset:       offset,
+		fileFullName: fileName,
+		fileIndex:    fid,
+	}, nil
 }
 
 func (v *vdbFile) NextFile() (*vdbFile, error) {
@@ -50,13 +58,16 @@ func (v *vdbFile) NextFile() (*vdbFile, error) {
 // 写进磁盘
 func (v *vdbFile) WriteEntry(entry []byte) (int64, error) {
 	if int64(len(entry))+v.offset > v.maxSize {
+		if err := v.writer.Flush(); err != nil {
+			return 0, err
+		}
 		nx, err := v.NextFile()
 		if err != nil {
 			return 0, err
 		}
 		*v = *nx
 	}
-	n, err := v.file.Write(entry)
+	n, err := v.writer.Write(entry)
 	if err != nil {
 		return 0, err
 	}
@@ -69,6 +80,7 @@ func (v *vdbFile) GetOffset() int64 {
 }
 
 func (v *vdbFile) Close() {
+	v.writer.Flush()
 	v.file.Close()
 }
 

--- a/lru.go
+++ b/lru.go
@@ -73,3 +73,13 @@ func (l *LruCache) Get(key string) *CacheItem {
 	}
 	return nil
 }
+
+func (l *LruCache) Del(key string) {
+	l.mux.Lock()
+	defer l.mux.Unlock()
+	e, ok := l.cache[key]
+	if ok {
+		l.list.Remove(e)
+		delete(l.cache, key)
+	}
+}

--- a/vaedb.go
+++ b/vaedb.go
@@ -117,9 +117,11 @@ func (v *VaeDB) loadData() error {
 // 	合并数据，打包旧数据
 func (v *VaeDB) mergeKeys() {
 	for newFileIndexWarp := range v.msgCh {
+		v.mux.Lock()
 		fIndex := v.keys.get(string(newFileIndexWarp.key))
 		if fIndex == nil {
 			v.logger.Println("not found Key", string(newFileIndexWarp.key))
+			v.mux.Unlock()
 			continue
 		}
 		fileIndex := fIndex.(*fileIndex)
@@ -127,10 +129,12 @@ func (v *VaeDB) mergeKeys() {
 		if fileIndex.fileId != getFileStr(v.activeFile.fileIndex) {
 			if newFileIndexWarp.fileIndex.timeStamp == 0 {
 				v.keys.del(string(newFileIndexWarp.key))
+				v.mux.Unlock()
 				continue
 			}
 			v.keys.set(string(newFileIndexWarp.key), newFileIndexWarp.fileIndex)
 		}
+		v.mux.Unlock()
 	}
 }
 
@@ -201,5 +205,6 @@ func (v *VaeDB) set(key string, val []byte, ts int64) error {
 
 //del 追加一条数据为空的纪录,且ts==0
 func (v *VaeDB) Del(key string) {
+	v.lruCache.Del(key) // 删除时清除缓存
 	v.set(key, []byte{}, 0)
 }


### PR DESCRIPTION
## 优化内容

### 1. 修复资源泄漏 (Bug)
- : 修复  位置错误，放在错误检查之后

### 2. LRU 缓存优化
- : 添加  方法，用于删除缓存条目
- : Del 操作时清除 LRU 缓存，避免删除后仍能从缓存读取旧数据

### 3. 并发安全修复
- :  函数中添加 mutex 锁，保护  的并发访问

### 4. 写入性能优化
- : 添加 64KB buffered writer，减少系统调用次数，提升写入性能

## 测试
建议运行测试验证修改：
```bash
go test -v -run Test
```